### PR TITLE
Update sample devfiles for odo compatibility

### DIFF
--- a/devfiles/eclipse/maven/1.0.0/devfile.yaml
+++ b/devfiles/eclipse/maven/1.0.0/devfile.yaml
@@ -10,24 +10,25 @@ components:
       mountSources: true
       endpoints:
         - name: '8080/http'
-          port: 8080
-          attributes:
+          configuration:
             discoverable: false
             public: true
-            protocol: http
+            protocol: tcp
+            scheme: http
+          targetPort: 8080
       volumeMounts:
         - name: m2
-          containerPath: /home/user/.m2
+          path: /home/user/.m2
 commands:
   - exec:
-      name: devBuild
+      id: devBuild
       component: tools
       commandLine: "mvn package"
       group:
         kind: build
         isDefault: true
   - exec:
-      name: devRun
+      id: devRun
       component: tools
       commandLine: "java -jar target/*.jar"
       group:

--- a/devfiles/eclipse/nodejs/1.0.0/devfile.yaml
+++ b/devfiles/eclipse/nodejs/1.0.0/devfile.yaml
@@ -14,14 +14,15 @@ components:
       mountSources: true
       endpoints:
         - name: "nodejs"
-          port: 3000
-          attributes:
+          configuration:
             discoverable: false
             public: true
-            protocol: http
+            protocol: tcp
+            scheme: http
+          targetPort: 3000
 commands:
   - exec:
-      name: devBuild
+      id: devBuild
       component: runtime
       commandLine: npm install
       workingDir: ${CHE_PROJECTS_ROOT}/nodejs-web-app/app
@@ -29,7 +30,7 @@ commands:
         kind: build
         isDefault: true
   - exec:
-      name: devRun
+      id: devRun
       component: runtime
       commandLine: nodemon app.js
       workingDir: ${CHE_PROJECTS_ROOT}/nodejs-web-app/app

--- a/devfiles/eclipse/openLiberty/1.0.0/devfile.yaml
+++ b/devfiles/eclipse/openLiberty/1.0.0/devfile.yaml
@@ -20,24 +20,26 @@ components:
       mountSources: true
       volumeMounts:
       - name: m2
-        containerPath: /home/user/.m2
+        path: /home/user/.m2
       endpoints:
       - name: 9080/http
-        port: 9080
-        attributes:
+        configuration:
           discoverable: false
           public: true
-          protocol: http
+          protocol: tcp
+          scheme: http
+        targetPort: 9080
       - name: 9443/https
-        port: 9443
-        attributes:
+        configuration:
           discoverable: false
           public: true
+          protocol: tcp
           secure: true
-          protocol: http
+          scheme: http
+        targetPort: 9443
 commands:
   - exec:
-      name: devBuild
+      id: devBuild
       component: devruntime
       commandLine: /artifacts/bin/build.sh
       workingDir: /projects/openLiberty
@@ -45,7 +47,7 @@ commands:
           kind: build
           isDefault: true
   - exec:
-      name: devRun
+      id: devRun
       component: devruntime
       commandLine: /artifacts/bin/run.sh
       workingDir: /projects/openLiberty

--- a/devfiles/eclipse/quarkus/1.0.0/devfile.yaml
+++ b/devfiles/eclipse/quarkus/1.0.0/devfile.yaml
@@ -11,24 +11,25 @@ components:
       mountSources: true
       volumeMounts:
         - name: m2
-          containerPath: /home/user/.m2
+          path: /home/user/.m2
       endpoints:
         - name: '8080/http'
-          port: 8080
-          attributes:
+          configuration:
             discoverable: false
             public: true
-            protocol: http
+            protocol: tcp
+            scheme: http
+          targetPort: 8080
 commands:
   - exec:
-      name: devInit
+      id: devInit
       component: tools
       commandLine: "mvn compile"
       group:
         kind: build
         isDefault: true
   - exec:
-      name: devRun
+      id: devRun
       component: tools
       commandLine: "mvn quarkus:dev"
       attributes:

--- a/devfiles/eclipse/springBoot/1.0.0/devfile.yaml
+++ b/devfiles/eclipse/springBoot/1.0.0/devfile.yaml
@@ -19,7 +19,7 @@ components:
       mountSources: true
       volumeMounts:
         - name: springbootpvc
-          containerPath: /data
+          path: /data
   - container:
       name: runtime
       image: maysunfaisal/springbootruntime
@@ -28,18 +28,19 @@ components:
       args: [ '-f', '/dev/null']
       endpoints:
         - name: '8080/tcp'
-          port: 8080
-          attributes:
+          configuration:
             discoverable: false
             public: true
-            protocol: http
+            protcol: tcp
+            scheme: http
+          targetPort: 8080
       mountSources: false
       volumeMounts:
         - name: springbootpvc
-          containerPath: /data
+          path: /data
 commands:
   - exec:
-      name: devBuild
+      id: devBuild
       component: tools
       commandLine: "/artifacts/bin/build-container-full.sh"
       workingDir: /projects/springbootproject
@@ -47,9 +48,9 @@ commands:
         kind: build
         isDefault: true
   - exec:
-      name: devRun
+      id: devRun
       component: runtime
-      command: "/artifacts/bin/start-server.sh"
+      commandLine: "/artifacts/bin/start-server.sh"
       workingDir: /
       group:
         kind: run


### PR DESCRIPTION
This PR updates sample devfiles for compatibility with odo's `parser-v2` branch, based on the latest spec available at https://devfile.github.io/website/devfile/index.html

The following changes are made:

- Changes `containerPath` to `path` for volumes
- Adds `configuration` field to endpoints
   - Replaces the attributes fields and makes sure `protocol`, `scheme`, `discoverable`, and `public` are set
- Changes `port` to `targetPort` in endpoints
- Replaces `name` to `id` for commands

I validated each devfile by doing the following:
1) `odo create`
2) `odo url create`
3) `odo push`

Steps 2 and 3 will spit out errors if an invalid devfile is used.

However, most of the devfiles are still broken on `odo push` (except for `maven` and `quarkus`), due to an issue in the `devfile-v2` branch in odo (not an issue with the devfiles). I'll be opening an issue in odo to track that.