### PR TITLE
Use projects instead of starterProjects

### DIFF
--- a/devfiles/eclipse/nodejs/1.0.0/devfile.yaml
+++ b/devfiles/eclipse/nodejs/1.0.0/devfile.yaml
@@ -2,7 +2,7 @@ schemaVersion: 2.0.0
 metadata:
   name: nodejs
   version: 1.0.0
-starterProjects:
+projects:
   - name: nodejs-web-app
     git:
       location: "https://github.com/odo-devfiles/nodejs-ex.git"

--- a/devfiles/eclipse/openLiberty/1.0.0/devfile.yaml
+++ b/devfiles/eclipse/openLiberty/1.0.0/devfile.yaml
@@ -5,8 +5,8 @@ metadata:
   description: Java application stack using Open Liberty runtime
 attributes:
   odo.autorestart: "false"
-starterProjects:
-  - name: openliberty
+projects:
+  - name: openLiberty
     git:
       location: https://github.com/odo-devfiles/openliberty-ex.git
 components:

--- a/devfiles/eclipse/openLiberty/1.0.0/devfile.yaml
+++ b/devfiles/eclipse/openLiberty/1.0.0/devfile.yaml
@@ -6,7 +6,7 @@ metadata:
 attributes:
   odo.autorestart: "false"
 projects:
-  - name: openLiberty
+  - name: openliberty
     git:
       location: https://github.com/odo-devfiles/openliberty-ex.git
 components:
@@ -42,7 +42,7 @@ commands:
       id: devBuild
       component: devruntime
       commandLine: /artifacts/bin/build.sh
-      workingDir: /projects/openLiberty
+      workingDir: /projects/openliberty
       group:
           kind: build
           isDefault: true
@@ -50,7 +50,7 @@ commands:
       id: devRun
       component: devruntime
       commandLine: /artifacts/bin/run.sh
-      workingDir: /projects/openLiberty
+      workingDir: /projects/openliberty
       group:
           kind: run
           isDefault: true

--- a/devfiles/eclipse/springBoot/1.0.0/devfile.yaml
+++ b/devfiles/eclipse/springBoot/1.0.0/devfile.yaml
@@ -2,7 +2,7 @@ schemaVersion: 2.0.0
 metadata:
   name: java-spring-boot
   version: 1.0.0
-starterProjects:
+projects:
   - name: springbootproject
     git:
       location: "https://github.com/odo-devfiles/springboot-ex.git"


### PR DESCRIPTION
This PR updates the sample v2 devfiles to use the `projects` field instead of `starterProjects`, so that the sample devfiles will work with odo, which doesn't have `starterProjects` implemented yet (see https://github.com/openshift/odo/issues/3263)